### PR TITLE
Step 3: Add pagination

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -3,5 +3,37 @@
  *
  * See: https://www.gatsbyjs.com/docs/node-apis/
  */
+const path = require("path")
 
-// You can delete this file if you're not using it
+const { paginate } = require("gatsby-awesome-pagination")
+
+exports.createPages = async ({ actions, graphql }) => {
+  const { createPage } = actions
+
+  const result = await graphql(
+    `
+      query PostsQuery {
+        allContentfulPost(sort: { fields: [createdAt], order: DESC }) {
+          nodes {
+            title
+            slug
+          }
+        }
+      }
+    `
+  )
+
+  if (result.errors) {
+    throw result.errors
+  }
+
+  const blogPosts = result.data.allContentfulPost.nodes
+
+  paginate({
+    createPage,
+    items: blogPosts,
+    itemsPerPage: 2,
+    pathPrefix: "/",
+    component: path.resolve("./src/templates/post-listing.js"),
+  })
+}

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "author": "Benedikt Rötsch <benedikt@techboi.io>",
   "dependencies": {
     "gatsby": "next",
+    "gatsby-awesome-pagination": "^0.3.6",
     "gatsby-plugin-gatsby-cloud": "next",
     "gatsby-plugin-manifest": "next",
     "gatsby-plugin-offline": "next",

--- a/src/pages/index.module.css
+++ b/src/pages/index.module.css
@@ -1,4 +1,0 @@
-.postsWrapper {
-  display: grid;
-  grid-gap: 2rem;
-}

--- a/src/templates/post-listing.js
+++ b/src/templates/post-listing.js
@@ -1,13 +1,13 @@
 import React from "react"
-import { graphql } from "gatsby"
+import { graphql, Link } from "gatsby"
 
 import Layout from "../components/layout"
 import SEO from "../components/seo"
 import PostTeaser from "../components/post-teaser"
 
-import * as styles from "./index.module.css"
+import * as styles from "./post-listing.module.css"
 
-const IndexPage = ({ data }) => {
+const PostListingTemplate = ({ data, pageContext }) => {
   const posts = data.allContentfulPost.nodes
 
   return (
@@ -20,15 +20,27 @@ const IndexPage = ({ data }) => {
           <PostTeaser post={post} key={post.slug} />
         ))}
       </div>
+      <div className={styles.pagination}>
+        {pageContext.previousPagePath && (
+          <Link to={pageContext.previousPagePath}>◂ Previous</Link>
+        )}
+        {pageContext.nextPagePath && (
+          <Link to={pageContext.nextPagePath}>Next ▸</Link>
+        )}
+      </div>
     </Layout>
   )
 }
 
-export default IndexPage
+export default PostListingTemplate
 
-export const query = graphql`
-  query IndexQuery {
-    allContentfulPost {
+export const pageQuery = graphql`
+  query PostListingQuery($skip: Int!, $limit: Int!) {
+    allContentfulPost(
+      sort: { fields: [createdAt], order: DESC }
+      skip: $skip
+      limit: $limit
+    ) {
       nodes {
         title
         slug

--- a/src/templates/post-listing.module.css
+++ b/src/templates/post-listing.module.css
@@ -1,0 +1,20 @@
+.postsWrapper {
+  display: grid;
+  grid-gap: 2rem;
+}
+
+.pagination {
+  display: flex;
+  justify-content: space-between;
+  margin-top: 2rem;
+}
+
+.pagination a {
+  border-radius: 1rem;
+  background: #eee;
+  display: inline-block;
+  padding: 0.15rem 0.6rem;
+  margin: 0 0.25rem 0.5rem 0;
+  color: black;
+  text-decoration: none;
+}


### PR DESCRIPTION
* Create post listing pages instead of rendering all posts at home route
* Use [gatsby-awesome-pagination](https://www.gatsbyjs.com/plugins/gatsby-awesome-pagination/) to create paginated listing pages